### PR TITLE
feat(bounties): add/remove supported tokens [8]

### DIFF
--- a/abi/contracts/Bounties.sol/Bounties.json
+++ b/abi/contracts/Bounties.sol/Bounties.json
@@ -295,6 +295,37 @@
     "type": "event"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "supported",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "symbol",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "decimals",
+        "type": "uint8"
+      }
+    ],
+    "name": "TokenSupportChange",
+    "type": "event"
+  },
+  {
     "inputs": [
       {
         "internalType": "string",
@@ -598,6 +629,32 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "_newToken",
+        "type": "address"
+      }
+    ],
+    "name": "ownerAddSupportedToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_removeToken",
+        "type": "address"
+      }
+    ],
+    "name": "ownerRemoveSupportedToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "_newOwner",
         "type": "address"
       }
@@ -787,6 +844,11 @@
         "internalType": "string",
         "name": "_issueId",
         "type": "string"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_tokens",
+        "type": "address[]"
       }
     ],
     "name": "sweepBounty",


### PR DESCRIPTION
- add ability for owner to add/remove supported tokens
- pass in tokens to `sweepBounty` to allow for granular sweeps and sweeping after token is no longer supported

fixes: #8 