### PR TITLE
feat(bounties): auto-claim for linked contributors [22]

### DIFF
--- a/abi/contracts/Bounties.sol/Bounties.json
+++ b/abi/contracts/Bounties.sol/Bounties.json
@@ -742,28 +742,28 @@
     "inputs": [
       {
         "internalType": "string",
-        "name": "",
+        "name": "platformId",
         "type": "string"
       },
       {
         "internalType": "string",
-        "name": "",
+        "name": "repoId",
         "type": "string"
       },
       {
         "internalType": "string",
-        "name": "",
+        "name": "issueId",
         "type": "string"
       },
       {
         "internalType": "address",
-        "name": "",
+        "name": "tokenContract",
         "type": "address"
       },
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
+        "internalType": "string",
+        "name": "platformUserId",
+        "type": "string"
       }
     ],
     "name": "claimed",

--- a/abi/contracts/IIdentity.sol/IIdentity.json
+++ b/abi/contracts/IIdentity.sol/IIdentity.json
@@ -3,6 +3,25 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "userAddress",
         "type": "address"
       },
@@ -59,6 +78,42 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "platformUser",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "platformId",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "userId",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "username",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct PlatformUser",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "string",
         "name": "platformId",
         "type": "string"
@@ -70,6 +125,30 @@
       }
     ],
     "name": "tokenIdForPlatformUser",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenOfOwnerByIndex",
     "outputs": [
       {
         "internalType": "uint256",

--- a/abi/contracts/Identity.sol/Identity.json
+++ b/abi/contracts/Identity.sol/Identity.json
@@ -604,7 +604,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "owner",
+        "name": "addr",
         "type": "address"
       }
     ],
@@ -987,22 +987,29 @@
         "type": "uint256"
       }
     ],
-    "name": "platformUserForTokenId",
+    "name": "platformUser",
     "outputs": [
       {
-        "internalType": "string",
-        "name": "platformId",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "userId",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "username",
-        "type": "string"
+        "components": [
+          {
+            "internalType": "string",
+            "name": "platformId",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "userId",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "username",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct PlatformUser",
+        "name": "",
+        "type": "tuple"
       }
     ],
     "stateMutability": "view",
@@ -1225,7 +1232,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "owner",
+        "name": "addr",
         "type": "address"
       },
       {

--- a/contracts/IIdentity.sol
+++ b/contracts/IIdentity.sol
@@ -1,6 +1,12 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.9;
 
+struct PlatformUser {
+    string platformId;
+    string userId;
+    string username;
+}
+
 interface IIdentity {
     function mint(
         address userAddress,
@@ -19,4 +25,16 @@ interface IIdentity {
         external
         view
         returns (address);
+
+    function balanceOf(address addr) external view returns (uint256);
+
+    function tokenOfOwnerByIndex(address addr, uint256 index)
+        external
+        view
+        returns (uint256);
+
+    function platformUser(uint256 tokenId)
+        external
+        view
+        returns (PlatformUser memory);
 }

--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -11,7 +11,7 @@ import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {Base64} from "@openzeppelin/contracts/utils/Base64.sol";
 import {AccessControlDefaultAdminRules} from "@openzeppelin/contracts/access/extensions/AccessControlDefaultAdminRules.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
-import {IIdentity} from "./IIdentity.sol";
+import {IIdentity, PlatformUser} from "./IIdentity.sol";
 
 contract Identity is
     IIdentity,
@@ -39,12 +39,6 @@ contract Identity is
     error InvalidSignature();
     error NotSupported();
 
-    struct PlatformUser {
-        string platformId;
-        string userId;
-        string username;
-    }
-
     bytes32 public constant CUSTODIAN_ADMIN_ROLE =
         keccak256("CUSTODIAN_ADMIN_ROLE");
     bytes32 public constant CUSTODIAN_ROLE = keccak256("CUSTODIAN_ROLE");
@@ -60,7 +54,7 @@ contract Identity is
     mapping(string platformId => mapping(string platformUserId => uint256 tokenId)) public tokenIdForPlatformUser;
 
     // TODO: do we need this?
-    mapping(uint256 tokenId => PlatformUser platformUser) public platformUserForTokenId;
+    mapping(uint256 tokenId => PlatformUser platformUser) private platformUserForTokenId;
 
     constructor(
         address _custodian,
@@ -265,4 +259,16 @@ contract Identity is
     }
 
     /** END NFT transfer overrides **/
+
+    function tokenOfOwnerByIndex(address addr, uint256 index) override(ERC721Enumerable,IIdentity) public view returns (uint256) {
+      return super.tokenOfOwnerByIndex(addr, index);
+    }
+
+    function balanceOf(address addr) override(ERC721,IERC721, IIdentity) public view returns (uint256) {
+      return super.balanceOf(addr);
+    }
+
+    function platformUser(uint256 tokenId) override(IIdentity) public view returns (PlatformUser memory) {
+      return platformUserForTokenId[tokenId];
+    }
 }

--- a/test/Identity.ts
+++ b/test/Identity.ts
@@ -75,7 +75,7 @@ describe("Identity", () => {
       await identity.mint(params[0], params[1], params[2], params[3], signature);
 
       // then
-      const result = await identity.platformUserForTokenId(1);
+      const result = await identity.platformUser(1);
       expect(result.platformId).to.equal(params[1]);
       expect(result.userId).to.equal(params[2]);
       expect(result.username).to.equal(params[3]);
@@ -182,7 +182,7 @@ describe("Identity", () => {
       await identity.transfer(params[0], params[1], params[2], params[3], signature);
 
       // then
-      const result = await identity.platformUserForTokenId(1);
+      const result = await identity.platformUser(1);
       expect(result.platformId).to.equal(params[1]);
       expect(result.userId).to.equal(params[2]);
       expect(result.username).to.equal(params[3]);


### PR DESCRIPTION
fixes: #22 

- Auto-claim linked contributor funds when maintainer claims
- Store claimed status using platformUserId instead of wallet address so user cannot xfer nft and claim again.